### PR TITLE
Add support for bool type

### DIFF
--- a/libsql.go
+++ b/libsql.go
@@ -420,6 +420,14 @@ func (c *conn) execute(query string, args []sqldriver.NamedValue) (C.libsql_rows
 			C.free(unsafe.Pointer(valueStr))
 		case nil:
 			statusCode = C.libsql_bind_null(stmt, C.int(idx), &errMsg)
+		case bool:
+			var valueInt int
+			if arg.Value.(bool) {
+				valueInt = 1
+			} else {
+				valueInt = 0
+			}
+			statusCode = C.libsql_bind_int(stmt, C.int(idx), C.longlong(valueInt), &errMsg)
 		default:
 			return nil, fmt.Errorf("unsupported type %T", arg.Value)
 		}


### PR DESCRIPTION
Sqlite supports insertion of bools as simple 0 and 1, so implementation is the same. From [sqlite.org](https://sqlite.org/datatype3.html):

> SQLite does not have a separate Boolean storage class. Instead, Boolean values are stored as integers 0 (false) and 1 (true).

Fixes #14 